### PR TITLE
Fix some transparent sprite issue

### DIFF
--- a/Assets/Shader/JitterFree.shader
+++ b/Assets/Shader/JitterFree.shader
@@ -16,6 +16,9 @@ Shader "Sprites/JitterFreeUnlit"
                 "CanUseSpriteAtlas" = "True"
             }
 
+            Cull Off
+            Lighting Off
+            ZWrite Off
             Blend One OneMinusSrcAlpha
 
             Pass


### PR DESCRIPTION
Hi! thx for your nice shader.

In unity 2021.3.2f1, it has two issue.

1. Not rendering when transform has negative scale.
2. Z order broken when two transparent sprite has different order in layer or tiled draw mode.

I simply fixed it.